### PR TITLE
appley new asm! style from RFC 2873

### DIFF
--- a/src/platform/linux-x86_64/mod.rs
+++ b/src/platform/linux-x86_64/mod.rs
@@ -14,42 +14,75 @@ pub mod nr;
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret: usize;
-    asm!("syscall", in("rax") n, out("rcx") _, lateout("rax") ret);
+    asm!("syscall",
+        in("rax") n,
+        out("rcx") _,
+        lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     let ret: usize;
-    asm!("syscall", in("rax") n, in("rdi") a1, out("rcx") _, lateout("rax") ret);
+    asm!("syscall",
+        in("rax") n,
+        in("rdi") a1,
+        out("rcx") _,
+        lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     let ret: usize;
-    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, out("rcx") _, lateout("rax") ret);
+    asm!("syscall",
+        in("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        out("rcx") _,
+        lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let ret: usize;
-    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, in("rdx") a3,out("rcx") _, lateout("rax") ret);
+    asm!("syscall",
+        in("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        out("rcx") _,
+        lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
     let ret: usize;
-    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, in("rdx") a3,in("r10") a4,out("rcx") _, lateout("rax") ret);
+    asm!("syscall",
+        in("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        out("rcx") _,
+        lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) -> usize {
     let ret: usize;
-    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, in("rdx") a3,in("r10") a4, in("r8") a5,out("rcx") _, lateout("rax") ret);
+    asm!("syscall",
+        in("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        in("r8") a5,
+        out("rcx") _,
+        lateout("rax") ret);
     ret
 }
 
@@ -64,6 +97,15 @@ pub unsafe fn syscall6(
     a6: usize,
 ) -> usize {
     let ret: usize;
-    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, in("rdx") a3,in("r10") a4, in("r8") a5, in("r9") a6,out("rcx") _, lateout("rax") ret);
+    asm!("syscall",
+        in("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        in("r8") a5,
+        in("r9") a6,
+        out("rcx") _,
+        lateout("rax") ret);
     ret
 }

--- a/src/platform/linux-x86_64/mod.rs
+++ b/src/platform/linux-x86_64/mod.rs
@@ -13,76 +13,57 @@ pub mod nr;
 
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
-    let ret : usize;
-    asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    let ret: usize;
+    asm!("syscall", in("rax") n, out("rcx") _, lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
-    let ret : usize;
-    asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    let ret: usize;
+    asm!("syscall", in("rax") n, in("rdi") a1, out("rcx") _, lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
-    let ret : usize;
-    asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    let ret: usize;
+    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, out("rcx") _, lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
-    let ret : usize;
-    asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    let ret: usize;
+    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, in("rdx") a3,out("rcx") _, lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
-pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize,
-                                a4: usize) -> usize {
-    let ret : usize;
-    asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
+    let ret: usize;
+    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, in("rdx") a3,in("r10") a4,out("rcx") _, lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
-pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize,
-                                a4: usize, a5: usize) -> usize {
-    let ret : usize;
-    asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4), "{r8}"(a5)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) -> usize {
+    let ret: usize;
+    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, in("rdx") a3,in("r10") a4, in("r8") a5,out("rcx") _, lateout("rax") ret);
     ret
 }
 
 #[inline(always)]
-pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
-                                a4: usize, a5: usize, a6: usize) -> usize {
-    let ret : usize;
-    asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4), "{r8}"(a5), "{r9}"(a6)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+pub unsafe fn syscall6(
+    n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
+    let ret: usize;
+    asm!("syscall", in("rax") n, in("rdi") a1,in("rsi") a2, in("rdx") a3,in("r10") a4, in("r8") a5, in("r9") a6,out("rcx") _, lateout("rax") ret);
     ret
 }


### PR DESCRIPTION
Previous asm! macro style is deprecated.
I replaced new style from rust RFC 2873.